### PR TITLE
[parachute] Parachute testsuite

### DIFF
--- a/assets/services/parachute/parachute.py
+++ b/assets/services/parachute/parachute.py
@@ -1,0 +1,182 @@
+import datetime
+import os
+import threading
+import time
+
+from pymavlink import mavutil
+from pymavlink.dialects.v20 import common as mavlink
+
+
+class ParachuteMavlinkUDPConnection:
+    """Class to handle parachute's MAVLink v2 UDP connections"""
+
+    def __init__(self, udpin_conn: str, udpout_conn: str, dialect: str) -> None:
+        """Initialize UDP connections"""
+        # Setting MAVLink version and dialect
+        os.environ["MAVLINK20"] = "1"
+        os.environ["MAVLINK_DIALECT"] = dialect
+        # Setting up UDP connections
+        self.udpin = mavutil.mavlink_connection(udpin_conn, dialect)
+        self.udpout = mavutil.mavlink_connection(udpout_conn, dialect)
+
+    def close(self):
+        """Close UDP connections"""
+        self.udpin.close()
+        self.udpout.close()
+
+
+class Parachute:
+    """Parachute class that uses MAVLink v2 UDP to broadcast heartbeat/status and handle commands"""
+
+    def __init__(
+        self,
+        dialect: str,
+        time_manufacture_s: int,
+        vendor_name: bytes,
+        model_name: bytes,
+        software_version: bytes,
+        hardware_version: bytes,
+        serial_number: bytes,
+        parachute_packed_date: bytes,
+    ) -> None:
+        # Initialize parachute info and status
+        self.info = mavlink.MAVLink_component_information_basic_message(
+            time_boot_ms=0,
+            capabilities=0,
+            time_manufacture_s=time_manufacture_s,
+            vendor_name=vendor_name,
+            model_name=model_name,
+            software_version=software_version,
+            hardware_version=hardware_version,
+            serial_number=serial_number,
+        )
+        self.status = mavlink.MAVLink_parachute_status_message(
+            time_boot_ms=0,
+            error_status=0,
+            arm_status=0,
+            deployment_status=mavlink.PARACHUTE_DEPLOYMENT_TRIGGER_NONE,
+            safety_status=mavlink.PARACHUTE_SAFETY_FLAGS_GROUND_CLEARED,
+            ats_arm_altitude=50,
+            parachute_packed_date=parachute_packed_date,
+        )
+        # Start parachute MAVLink UDP connections
+        self.mavlink_udp_connection = ParachuteMavlinkUDPConnection(
+            udpin_conn="udpin:localhost:14540",
+            udpout_conn="udpout:localhost:14541",
+            dialect=dialect,
+        )
+        # Start publishing heartbeat at 1Hz
+        self.heartbeat_thread_event = threading.Event()
+        heartbeat_thread = threading.Thread(
+            target=self.stream_heartbeat,
+            daemon=True,
+        )
+        heartbeat_thread.start()
+        self.heartbeat_thread_event.set()
+        # Start publish parachute status at 1Hz
+        self.parachute_status_thread_event = threading.Event()
+        parachute_status_thread = threading.Thread(
+            target=self.stream_parachute_status,
+            daemon=True,
+        )
+        parachute_status_thread.start()
+        self.parachute_status_thread_event.set()
+
+    def stream_heartbeat(self) -> None:
+        """Stream parachute heartbeat at 1Hz"""
+        while True:
+            self.heartbeat_thread_event.wait()
+            self.mavlink_udp_connection.udpout.mav.heartbeat_send(
+                mavlink.MAV_TYPE_PARACHUTE, mavlink.MAV_AUTOPILOT_INVALID, 0, 0, 0
+            )
+            time.sleep(1)
+
+    def stream_parachute_status(self) -> None:
+        """Stream parachute status at 1Hz"""
+        while True:
+            self.parachute_status_thread_event.wait()
+            self.mavlink_udp_connection.udpout.mav.send(self.status)
+            time.sleep(1)
+
+    def listen_for_commands(self) -> None:
+        """Listen for MAVLink commands"""
+        while True:
+            msg = self.mavlink_udp_connection.udpin.recv_match(type="COMMAND_LONG", blocking=True)
+            if msg:
+                self.handle_command_long(msg)
+
+    def handle_command_long(self, msg: mavlink.MAVLink_command_long_message) -> None:
+        """Handle MAVLink command long messages"""
+        if msg.command == mavlink.MAV_CMD_REQUEST_MESSAGE:
+            self.handle_command_request_message(msg)
+        elif msg.command == mavlink.MAV_CMD_DO_PARACHUTE:
+            self.handle_command_do_parachute(msg)
+        elif msg.command == mavlink.MAV_CMD_SET_PARACHUTE_ARM:
+            self.handle_command_set_parachute_arm(msg)
+        else:
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_UNSUPPORTED
+            )
+
+    def handle_command_request_message(self, msg: mavlink.MAVLink_command_long_message) -> None:
+        """Handle MAVLink request message command"""
+        if msg.param1 == mavlink.MAVLINK_MSG_ID_PARACHUTE_STATUS:
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_ACCEPTED
+            )
+            self.mavlink_udp_connection.udpout.mav.send(self.status)
+        elif msg.param1 == mavlink.MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC:
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_ACCEPTED
+            )
+            self.mavlink_udp_connection.udpout.mav.send(self.info)
+        else:
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_DENIED
+            )
+
+    def handle_command_do_parachute(self, msg: mavlink.MAVLink_command_long_message) -> None:
+        """Handle MAVLink do parachute command"""
+        result = mavlink.MAV_RESULT_DENIED
+        if msg.param1 == mavlink.PARACHUTE_RELEASE:
+            if self.status.arm_status & mavlink.PARACHUTE_TRIGGER_FLAGS_FC:
+                if self.status.safety_status & mavlink.PARACHUTE_SAFETY_FLAGS_GROUND_CLEARED:
+                    result = mavlink.MAV_RESULT_ACCEPTED
+                    self.status.deployment_status = mavlink.PARACHUTE_DEPLOYMENT_TRIGGER_DRONE
+                else:
+                    result = mavlink.MAV_RESULT_TEMPORARILY_REJECTED
+            else:
+                result = mavlink.MAV_RESULT_FAILED
+        self.mavlink_udp_connection.udpout.mav.command_ack_send(msg.command, result=result)
+
+    def handle_command_set_parachute_arm(self, msg: mavlink.MAVLink_command_long_message) -> None:
+        """Handle MAVLink set parachute arm command"""
+        arm_flags = int(msg.param1)
+        bitmask = int(msg.param2)
+        valid_parachute_trigger_flags = ((mavlink.PARACHUTE_TRIGGER_FLAGS_ENUM_END - 1) << 1) - 1
+        if arm_flags & ~valid_parachute_trigger_flags or bitmask & ~valid_parachute_trigger_flags:
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_DENIED
+            )
+        else:
+            new_arm_status = self.status.arm_status & ~bitmask
+            new_arm_status |= arm_flags & bitmask
+            self.status.arm_status = new_arm_status
+            self.mavlink_udp_connection.udpout.mav.command_ack_send(
+                msg.command, result=mavlink.MAV_RESULT_ACCEPTED
+            )
+
+
+if __name__ == "__main__":
+    # Create parachute object and start listening for commands
+    parachute = Parachute(
+        dialect="common",
+        time_manufacture_s=int(time.time()),
+        vendor_name=b"Vendor",
+        model_name=b"Model",
+        software_version=b"1.2.3",
+        hardware_version=b"4.5.6",
+        serial_number=b"123456",
+        parachute_packed_date=datetime.date.today().strftime("%Y-%m-%d").encode(),
+    )
+    parachute.listen_for_commands()

--- a/assets/services/parachute/test_parachute.py
+++ b/assets/services/parachute/test_parachute.py
@@ -1,0 +1,299 @@
+import os
+import unittest
+
+from pymavlink import mavutil
+from pymavlink.dialects.v20 import common as mavlink
+
+
+class UnittestMavlinkUDPConnection:
+    """Class to handle MAVLink UDP connections"""
+
+    def __init__(self):
+        """Initialize UDP connections for unittests based on environment variables"""
+        dialect = os.getenv("MAVLINK_DIALECT", "common")
+        udpin = os.getenv("MAVLINK_UDPIN", "udpin:localhost:14541")
+        udpout = os.getenv("MAVLINK_UDPOUT", "udpout:localhost:14540")
+        self.udpin = mavutil.mavlink_connection(udpin, dialect=dialect)
+        self.udpout = mavutil.mavlink_connection(udpout, dialect=dialect)
+
+    def close(self):
+        """Close UDP connections"""
+        self.udpin.close()
+        self.udpout.close()
+
+
+class ParachuteMavlinkTestCaseBase(unittest.TestCase):
+    """Base class for parachute MAVLink test cases"""
+
+    MSG_TIMEOUT = 3
+
+    @classmethod
+    def setUpClass(cls):
+        cls.parachute_connection = UnittestMavlinkUDPConnection()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.parachute_connection.close()
+
+    def encode_and_send_mavlink_command_long(
+        self, command: int, param1: float, param2: float = 0
+    ) -> None:
+        """Encode and send a MAVLink COMMAND_LONG message"""
+        msg = self.parachute_connection.udpout.mav.command_long_encode(
+            self.parachute_connection.udpout.target_system,  # Target System
+            self.parachute_connection.udpout.target_component,  # Target Component
+            command,  # Command
+            0,  # Confirmation
+            param1,  # param1
+            param2,  # param2
+            0,  # param3 (unused)
+            0,  # param4 (unused)
+            0,  # param5 (unused)
+            0,  # param6 (unused)
+            0,  # param7: Response Target - flight-stack default
+        )
+        self.parachute_connection.udpout.mav.send(msg)
+
+    def assert_mavlink_command_ack(self, command: int, result: int):
+        """Assert that a COMMAND_ACK message is recieved"""
+        ack = self.parachute_connection.udpin.recv_match(
+            type="COMMAND_ACK", blocking=True, timeout=self.MSG_TIMEOUT
+        )
+        self.assertIsNotNone(ack, "Did not recieve a COMMAND_ACK message")
+        self.assertEqual(
+            ack.command, command, f"Did not recieve a COMMAND_ACK message for {command}"
+        )
+        self.assertEqual(ack.result, result, f"Did not recieve a {result} COMMAND_ACK message")
+
+    def receive_parachute_status_with_assert(self) -> mavlink.MAVLink_parachute_status_message:
+        """Assert that a PARACHUTE_STATUS message is recieved"""
+        msg = self.parachute_connection.udpin.recv_match(
+            type="PARACHUTE_STATUS", blocking=True, timeout=self.MSG_TIMEOUT
+        )
+        self.assertIsNotNone(msg, "Did not recieve a PARACHUTE_STATUS message")
+        return msg
+
+
+class ParachuteBasicMavlinkMessagesTestCase(ParachuteMavlinkTestCaseBase):
+    """Test cases for recieving basic MAVLink messages"""
+
+    def test_heartbeat(self):
+        """Test recieving a MAVLink heartbeat message from parachute"""
+        msg = self.parachute_connection.udpin.recv_match(
+            type="HEARTBEAT", blocking=True, timeout=self.MSG_TIMEOUT
+        )
+        self.assertIsNotNone(msg, "Did not recieve a HEARTBEAT message")
+        self.assertEqual(
+            msg.type, mavlink.MAV_TYPE_PARACHUTE, "HEARTBEAT message type is not parachute"
+        )
+
+    def test_component_information_basic_request(self):
+        """Test requesting and receiving a parachute information basic message"""
+        # Request component information basic message
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_REQUEST_MESSAGE,
+            mavlink.MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_REQUEST_MESSAGE, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.parachute_connection.udpin.recv_match(
+            type="COMPONENT_INFORMATION_BASIC", blocking=True, timeout=self.MSG_TIMEOUT
+        )
+        self.assertIsNotNone(msg, "Did not recieve a COMPONENT_INFORMATION_BASIC message")
+
+    def test_parachute_status(self):
+        """Test recieving a parachute status message"""
+        self.receive_parachute_status_with_assert()
+
+
+class MavlinkSetParachuteArmTestCase(ParachuteMavlinkTestCaseBase):
+    """Test cases for arming parachute"""
+
+    def setUp(self):
+        self.receive_parachute_status_with_assert()
+
+    def tearDown(self):
+        # Disarm all triggers
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            0,
+            ((mavlink.PARACHUTE_TRIGGER_FLAGS_ENUM_END - 1) << 1) - 1,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertFalse(msg.arm_status, f"Parachute arm status not disarmed: {msg}")
+
+    def test_arm_ats(self):
+        """Test arming parachute with just ATS trigger"""
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status == mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            "Parachute is not armed with just ATS trigger",
+        )
+
+    def test_arm_fc(self):
+        """Test arming parachute with just FC trigger"""
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status == mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            "Parachute is not armed with just FC trigger",
+        )
+
+    def test_arm_ats_and_fc(self):
+        """Test arming parachute with both ATS and FC triggers at the same time"""
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS | mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS | mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status
+            == (mavlink.PARACHUTE_TRIGGER_FLAGS_ATS | mavlink.PARACHUTE_TRIGGER_FLAGS_FC),
+            "Parachute is not armed with both ATS and FC triggers",
+        )
+
+    def test_arm_ats_then_fc(self):
+        """Test arming parachute with ATS trigger and then FC trigger"""
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status == mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            "Parachute is not armed with just ATS trigger",
+        )
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status
+            == (mavlink.PARACHUTE_TRIGGER_FLAGS_ATS | mavlink.PARACHUTE_TRIGGER_FLAGS_FC),
+            "Parachute is not armed with both ATS and FC triggers",
+        )
+
+    def test_arm_invalid_upper_bound(self):
+        """Test arming parachute with invalid upper bound trigger flag"""
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ENUM_END << 1,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ENUM_END << 1,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_DENIED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertFalse(msg.arm_status, f"Upper bound trigger flag set in arm status: {msg}")
+
+
+class MavlinkDeployParachuteTestCase(ParachuteMavlinkTestCaseBase):
+    """Test cases for deploying parachute"""
+
+    def setUp(self):
+        msg = self.receive_parachute_status_with_assert()
+        self.assertFalse(msg.arm_status, f"Parachute arm status not disarmed: {msg}")
+        self.assertFalse(msg.deployment_status, f"Parachute already deployed: {msg}")
+
+    def tearDown(self):
+        # Disarm all triggers
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            0,
+            ((mavlink.PARACHUTE_TRIGGER_FLAGS_ENUM_END - 1) << 1) - 1,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertFalse(msg.arm_status, f"Parachute arm status not disarmed: {msg}")
+
+    def test_deploy_parachute_with_ats(self):
+        """Test DO_PARACHUTE should not deploy parachute with ATS trigger"""
+        # Arm just the ATS trigger
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status == mavlink.PARACHUTE_TRIGGER_FLAGS_ATS,
+            "Parachute is not armed with just ATS trigger",
+        )
+        # Deploy parachute
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_DO_PARACHUTE,
+            mavlink.PARACHUTE_RELEASE,
+        )
+        self.assert_mavlink_command_ack(mavlink.MAV_CMD_DO_PARACHUTE, mavlink.MAV_RESULT_FAILED)
+        msg = self.receive_parachute_status_with_assert()
+        self.assertFalse(msg.deployment_status, f"Parachute deployed: {msg}")
+
+    def test_deploy_parachute_with_fc(self):
+        """Test DO_PARACHUTE should deploy parachute with FC trigger armed"""
+        # Arm FC trigger
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+        )
+        self.assert_mavlink_command_ack(
+            mavlink.MAV_CMD_SET_PARACHUTE_ARM, mavlink.MAV_RESULT_ACCEPTED
+        )
+        msg = self.receive_parachute_status_with_assert()
+        self.assertTrue(
+            msg.arm_status == mavlink.PARACHUTE_TRIGGER_FLAGS_FC,
+            "Parachute is not armed with just FC trigger",
+        )
+        # Deploy parachute
+        self.encode_and_send_mavlink_command_long(
+            mavlink.MAV_CMD_DO_PARACHUTE,
+            mavlink.PARACHUTE_RELEASE,
+        )
+        self.assert_mavlink_command_ack(mavlink.MAV_CMD_DO_PARACHUTE, mavlink.MAV_RESULT_ACCEPTED)
+        msg = self.receive_parachute_status_with_assert()
+        self.assertEqual(
+            msg.deployment_status,
+            mavlink.PARACHUTE_DEPLOYMENT_TRIGGER_DRONE,
+            f"Parachute did not deployed: {msg}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The script `parachute.py` emulates a parachute module that has MAVLink v2 UDP connections.
The script `test_parachute.py` runs a standard test suite and can be used to test the emulator with its default settings.

Instructions:
1. Run simple parachute emulator `python3 parachute.py`
2. Run test `MAVLINK20=1 python3 test_parachute.py` (or `MAVLINK20=1 python3 -m unittest -v test_parachute.py` for more verbosity)

To use the test suite on other parachute modules, set the relevant env variables `MAVLINK_DIALECT`, `MAVLINK_UDPIN`, and `MAVLINK_UDPOUT`: `MAVLINK20=1 MAVLINK_DIALECT=dialect MAVLINK_UDPIN=udpin MAVLINK_UDPOUT=udpout python3 test_parachute.py`

Topic: parachute_testsuite